### PR TITLE
Pipeline watch

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -66,9 +66,10 @@ class PipelineSpy(object):
         mock = getattr(self, method)
         mock.assert_called_with(*args, **kwargs)
 
-    def reset_mocks(self):
-        for mock in self.method_mocks.values():
-            mock.reset_mock()
+    def reset_mock(self):
+        # Reset all method mocks
+        for _mock in self.method_mocks.values():
+            _mock.reset_mock()
 
 
 class MethodSpy(object):
@@ -83,7 +84,6 @@ class MethodSpy(object):
     def _convert_call(self, call):
         args = call[0][1:]   # erase first arg
         kwargs = call[1]
-        print 'call', args, kwargs
         return mock.call(*args, **kwargs)
 
     @property

--- a/rohm/models.py
+++ b/rohm/models.py
@@ -1,7 +1,8 @@
 import copy
+import logging
 
 import six
-import logging
+import redis
 
 from rohm import model_registry
 from rohm.fields import BaseField, IntegerField, RelatedModelField, RelatedModelIdField
@@ -285,9 +286,6 @@ class Model(six.with_metaclass(ModelMetaclass)):
 
         redis_key = self.get_redis_key()
 
-        if self._new and not force_create and conn.exists(redis_key):
-            raise AlreadyExists
-
         modified_data = None
 
         if modified_only and not self._new:
@@ -297,21 +295,29 @@ class Model(six.with_metaclass(ModelMetaclass)):
             cleaned_data, none_keys = self.get_cleaned_data()
 
         if cleaned_data or none_keys:
-            use_pipe = cleaned_data and none_keys or self.ttl
+            with conn.pipeline() as pipe:
+                try:
+                    if self._new and not force_create:
+                        pipe.watch(redis_key)
 
-            with redis_operation(conn, pipelined=use_pipe) as _conn:
-                if cleaned_data:
-                    _conn.hmset(redis_key, cleaned_data)
+                    pipe.multi()
 
-                if none_keys:
-                    # Delete None values
-                    _conn.hdel(redis_key, *none_keys)
+                    if cleaned_data:
+                        pipe.hmset(redis_key, cleaned_data)
 
-                if self.ttl:
-                    _conn.expire(redis_key, self.ttl)
+                    if none_keys:
+                        # Delete None values
+                        pipe.hdel(redis_key, *none_keys)
 
-                # Custom save hook
-                self.on_save(conn, modified_data=modified_data)
+                    if self.ttl:
+                        pipe.expire(redis_key, self.ttl)
+
+                    # Custom save hook
+                    self.on_save(conn, modified_data=modified_data)
+
+                    pipe.execute()
+                except redis.WatchError:
+                    raise AlreadyExists
 
             if self.track_modified_fields:
                 self._reset_orig_data()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -51,4 +51,3 @@ def test_datetime_field():
 
     foo = DefaultTimeModel.get(id=1)
     assert foo.created_at
-    print foo.created_at

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -102,7 +102,7 @@ def test_non_id_primary_key(pipe):
 
 class TestNoneField(object):
 
-    def test_none_field_basics(self, conn):
+    def test_none_field_basics(self, conn, pipe):
 
         """
         Test behavior of allow_none fields
@@ -123,13 +123,13 @@ class TestNoneField(object):
         redis_key = 'foo:1'
 
         # should be no calls get (bug with name __get__ calling from Redis)
-        assert conn.hmget.call_count == 0
+        assert pipe.hmget.call_count == 0
 
-        conn.reset_mock()
+        pipe.reset_mock()
 
         # understand that we already "loaded" that this field is None
         foo = Foo.get(id=1)
-        assert conn.mock_calls == [call.hgetall(redis_key)]
+        pipe.hgetall.assert_called_with(redis_key)
         assert foo._loaded_field_names == {'id', 'name'}
 
         assert foo.name is None   # this should not trigger Redis call
@@ -137,15 +137,15 @@ class TestNoneField(object):
         foo.name = 'asdf'
         assert foo._get_modified_fields() == {'name': 'asdf'}
         foo.save()
-        assert conn.mock_calls[-1] == call.hmset(redis_key, {'name': 'asdf'})
+        pipe.hmset.assert_called_with(redis_key, {'name': 'asdf'})
         assert conn.hgetall(redis_key) == {'id': '1', 'name': 'asdf'}
 
-        conn.reset_mock()
+        pipe.reset_mock()
 
         # Now try overriding existing value with None! Should do a delete operation
         foo.name = None
         foo.save()
-        assert conn.mock_calls == [call.hdel(redis_key, 'name')]
+        pipe.hdel.assert_called_with(redis_key, 'name')
         assert conn.hgetall(redis_key) == {'id': '1'}
 
     def test_none_field_mixed(self, conn, pipe):
@@ -178,7 +178,7 @@ class TestNoneField(object):
 
 
 @pytest.mark.parametrize('save_modified_only', (False, True))
-def test_save_modified_only(save_modified_only, conn):
+def test_save_modified_only(save_modified_only, conn, pipe):
     class Foo(Model):
         name = fields.CharField()
         num = fields.IntegerField()
@@ -189,26 +189,25 @@ def test_save_modified_only(save_modified_only, conn):
 
     foo = Foo.get(1)
 
-    conn.reset_mock()
+    pipe.reset_mock()
     foo.name = 'something'
     foo.save()
 
     if save_modified_only:
-        print conn.mock_calls
-        conn.hmset.assert_called_once_with('foo:1', {'name': 'something'})
+        pipe.hmset.assert_called_with('foo:1', {'name': 'something'})
 
         # next save should do nothing
         foo.save()
-        conn.reset_mock()
-        assert conn.mock_calls == []
+        pipe.reset_mock()
+        assert pipe.hmset.call_count == 0
     else:
         data = {'id': '1', 'name': 'something', 'num': '12'}
-        conn.hmset.assert_called_once_with('foo:1', data)
+        pipe.hmset.assert_called_with('foo:1', data)
 
         # other saves will still save, sadly
-        conn.reset_mock()
+        pipe.reset_mock()
         foo.save()
-        conn.hmset.assert_called_once_with('foo:1', data)
+        pipe.hmset.assert_called_with('foo:1', data)
 
 
 def test_ttl(conn, pipe):
@@ -244,7 +243,7 @@ def test_partial_fields(conn, pipe):
     assert foo._loaded_field_names == {'id', 'name'}
     assert pipe.hmget.call_count == 1
 
-    pipe.reset_mocks()
+    pipe.reset_mock()
 
     # access another field
     assert foo.num == 20
@@ -256,7 +255,7 @@ def test_partial_fields(conn, pipe):
     assert foo._loaded_field_names == {'id', 'name', 'num'}
 
     # access again
-    print foo.num
+    str(foo.num)
     assert pipe.hget.call_count == 1
 
 
@@ -279,7 +278,7 @@ def test_get_multi(Foo, conn, pipe):
     assert foos[1].id == 2
 
     # Test partial fields access
-    pipe.reset_mocks()
+    pipe.reset_mock()
     foos = Foo.get([1, 2], fields=['name'])
 
     assert pipe.hmget.call_count == 2


### PR DESCRIPTION
@elaser @andyfang 

- better support for race conditions on creating a new model, in case another process created it. uses Redis watch (https://github.com/andymccurdy/redis-py#pipelines) feature to detect for changes
- some test cleanup